### PR TITLE
Toggle enterprise feature

### DIFF
--- a/charts/cp-kafka/Chart.yaml
+++ b/charts/cp-kafka/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Confluent Kafka on Kubernetes
 name: cp-kafka
-version: 0.1.0
+version: 0.1.1

--- a/charts/cp-kafka/Chart.yaml
+++ b/charts/cp-kafka/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Confluent Kafka on Kubernetes
 name: cp-kafka
-version: 0.1.1
+version: 0.1.0

--- a/charts/cp-kafka/README.md
+++ b/charts/cp-kafka/README.md
@@ -112,13 +112,13 @@ The configuration parameters in this section control the resources requested and
 
 ### Image
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `image` | Docker Image of Confluent Kafka. | `confluentinc/cp-enterprise-kafka` |
-| `imageTag` | Docker Image Tag of Confluent Kafka. | `6.2.1` |
-| `imagePullPolicy` | Docker Image Tag of Confluent Kafka. | `IfNotPresent` |
-| `imagePullSecrets` | Secrets to be used for private registries. | see [values.yaml](values.yaml) for details |
-| `enableEnterpriseFeatures` | If this flag is set to `true`, Kafka image will be set to `confluentinc/cp-enterprise-kafka` otherwise it will be set to `confluentinc/cp-kafka` (Community version). It can still be overridden in `values.yaml`. | `true`
+| Parameter | Description                                                                                                                                                                                              | Default                                    |
+| --------- |----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------|
+| `image` | Docker Image of Confluent Kafka.                                                                                                                                                                         | `confluentinc/cp-server`                   |
+| `imageTag` | Docker Image Tag of Confluent Kafka.                                                                                                                                                                     | `6.2.1`                                    |
+| `imagePullPolicy` | Docker Image Tag of Confluent Kafka.                                                                                                                                                                     | `IfNotPresent`                             |
+| `imagePullSecrets` | Secrets to be used for private registries.                                                                                                                                                               | see [values.yaml](values.yaml) for details |
+| `enableEnterpriseFeatures` | If this flag is set to `true`, Kafka image will be set to `confluentinc/cp-server` otherwise it will be set to `confluentinc/cp-kafka` (Community version). It can still be overridden in `values.yaml`. | `true`                                     
 
 ### StatefulSet Configurations
 

--- a/charts/cp-kafka/README.md
+++ b/charts/cp-kafka/README.md
@@ -112,13 +112,13 @@ The configuration parameters in this section control the resources requested and
 
 ### Image
 
-| Parameter | Description                                                                                                                                                                                              | Default                                    |
-| --------- |----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------|
-| `image` | Docker Image of Confluent Kafka.                                                                                                                                                                         | `confluentinc/cp-server`                   |
-| `imageTag` | Docker Image Tag of Confluent Kafka.                                                                                                                                                                     | `6.2.1`                                    |
-| `imagePullPolicy` | Docker Image Tag of Confluent Kafka.                                                                                                                                                                     | `IfNotPresent`                             |
-| `imagePullSecrets` | Secrets to be used for private registries.                                                                                                                                                               | see [values.yaml](values.yaml) for details |
-| `enableEnterpriseFeatures` | If this flag is set to `true`, Kafka image will be set to `confluentinc/cp-server` otherwise it will be set to `confluentinc/cp-kafka` (Community version). It can still be overridden in `values.yaml`. | `true`                                     
+| Parameter                  | Description                                                                                                                                                                                              | Default                                    |
+|----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------|
+| `image`                    | Docker Image of Confluent Kafka.                                                                                                                                                                         | `confluentinc/cp-server`                   |
+| `imageTag`                 | Docker Image Tag of Confluent Kafka.                                                                                                                                                                     | `6.2.1`                                    |
+| `imagePullPolicy`          | Docker Image Tag of Confluent Kafka.                                                                                                                                                                     | `IfNotPresent`                             |
+| `imagePullSecrets`         | Secrets to be used for private registries.                                                                                                                                                               | see [values.yaml](values.yaml) for details |
+| `enableEnterpriseFeatures` | If this flag is set to `true`, Kafka image will be set to `confluentinc/cp-server` otherwise it will be set to `confluentinc/cp-kafka` (Community version). It can still be overridden in `values.yaml`. | `true`                                     |
 
 ### StatefulSet Configurations
 

--- a/charts/cp-kafka/README.md
+++ b/charts/cp-kafka/README.md
@@ -118,6 +118,7 @@ The configuration parameters in this section control the resources requested and
 | `imageTag` | Docker Image Tag of Confluent Kafka. | `6.2.1` |
 | `imagePullPolicy` | Docker Image Tag of Confluent Kafka. | `IfNotPresent` |
 | `imagePullSecrets` | Secrets to be used for private registries. | see [values.yaml](values.yaml) for details |
+| `enableEnterpriseFeatures` | If enterprise feautres shall be enabled. Requries the image to be `confluentinc/cp-enterprise-kafka`. If disabled, it works with `confluentinc/cp-kafka` | `true`
 
 ### StatefulSet Configurations
 

--- a/charts/cp-kafka/README.md
+++ b/charts/cp-kafka/README.md
@@ -118,7 +118,7 @@ The configuration parameters in this section control the resources requested and
 | `imageTag` | Docker Image Tag of Confluent Kafka. | `6.2.1` |
 | `imagePullPolicy` | Docker Image Tag of Confluent Kafka. | `IfNotPresent` |
 | `imagePullSecrets` | Secrets to be used for private registries. | see [values.yaml](values.yaml) for details |
-| `enableEnterpriseFeatures` | If enterprise feautres shall be enabled. Requries the image to be `confluentinc/cp-enterprise-kafka`. If disabled, it works with `confluentinc/cp-kafka` | `true`
+| `enableEnterpriseFeatures` | If this flag is set to `true`, Kafka image will be set to `confluentinc/cp-enterprise-kafka` otherwise it will be set to `confluentinc/cp-kafka` (Community version) | `true`
 
 ### StatefulSet Configurations
 

--- a/charts/cp-kafka/README.md
+++ b/charts/cp-kafka/README.md
@@ -118,7 +118,7 @@ The configuration parameters in this section control the resources requested and
 | `imageTag` | Docker Image Tag of Confluent Kafka. | `6.2.1` |
 | `imagePullPolicy` | Docker Image Tag of Confluent Kafka. | `IfNotPresent` |
 | `imagePullSecrets` | Secrets to be used for private registries. | see [values.yaml](values.yaml) for details |
-| `enableEnterpriseFeatures` | If this flag is set to `true`, Kafka image will be set to `confluentinc/cp-enterprise-kafka` otherwise it will be set to `confluentinc/cp-kafka` (Community version) | `true`
+| `enableEnterpriseFeatures` | If this flag is set to `true`, Kafka image should be set to `confluentinc/cp-enterprise-kafka` in `values.yaml` otherwise it should be set to `confluentinc/cp-kafka` (Community version) | `true`
 
 ### StatefulSet Configurations
 

--- a/charts/cp-kafka/README.md
+++ b/charts/cp-kafka/README.md
@@ -118,7 +118,7 @@ The configuration parameters in this section control the resources requested and
 | `imageTag` | Docker Image Tag of Confluent Kafka. | `6.2.1` |
 | `imagePullPolicy` | Docker Image Tag of Confluent Kafka. | `IfNotPresent` |
 | `imagePullSecrets` | Secrets to be used for private registries. | see [values.yaml](values.yaml) for details |
-| `enableEnterpriseFeatures` | If this flag is set to `true`, Kafka image should be set to `confluentinc/cp-enterprise-kafka` in `values.yaml` otherwise it should be set to `confluentinc/cp-kafka` (Community version) | `true`
+| `enableEnterpriseFeatures` | If this flag is set to `true`, Kafka image will be set to `confluentinc/cp-enterprise-kafka` otherwise it will be set to `confluentinc/cp-kafka` (Community version). It can still be overridden in `values.yaml`. | `true`
 
 ### StatefulSet Configurations
 

--- a/charts/cp-kafka/templates/statefulset.yaml
+++ b/charts/cp-kafka/templates/statefulset.yaml
@@ -128,10 +128,12 @@ spec:
           value: {{ include "cp-kafka.cp-zookeeper.service-name" . | quote }}
         - name: KAFKA_LOG_DIRS
           value: {{ include "cp-kafka.log.dirs" . | quote }}
+        {{- if .Values.enableEnterpriseFeatures }}
         - name: KAFKA_METRIC_REPORTERS
           value: "io.confluent.metrics.reporter.ConfluentMetricsReporter"
         - name: CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS
           value: {{ printf "PLAINTEXT://%s:9092" (include "cp-kafka.cp-kafka-headless.fullname" .) | quote }}
+        {{- end }}
         {{- range $key, $value := .Values.configurationOverrides }}
         - name: {{ printf "KAFKA_%s" $key | replace "." "_" | upper | quote }}
           value: {{ $value | quote }}

--- a/charts/cp-kafka/templates/statefulset.yaml
+++ b/charts/cp-kafka/templates/statefulset.yaml
@@ -83,7 +83,13 @@ spec:
           mountPath: /etc/jmx-kafka
       {{- end }}
       - name: {{ template "cp-kafka.name" . }}-broker
+        {{- if .Values.image }}
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        {{- else if .Values.enableEnterpriseFeatures }}
+        image: "confluentinc/cp-enterprise-kafka:{{ .Values.imageTag }}"
+        {{- else }}
+        image: "confluentinc/cp-kafka:{{ .Values.imageTag }}"
+        {{- end }}
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         {{- if .Values.securityContext }}
         securityContext: {{- toYaml .Values.securityContext | nindent 10 }}

--- a/charts/cp-kafka/templates/statefulset.yaml
+++ b/charts/cp-kafka/templates/statefulset.yaml
@@ -86,7 +86,7 @@ spec:
         {{- if .Values.image }}
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         {{- else if .Values.enableEnterpriseFeatures }}
-        image: "confluentinc/cp-enterprise-kafka:{{ .Values.imageTag }}"
+        image: "confluentinc/cp-server:{{ .Values.imageTag }}"
         {{- else }}
         image: "confluentinc/cp-kafka:{{ .Values.imageTag }}"
         {{- end }}

--- a/charts/cp-kafka/values.yaml
+++ b/charts/cp-kafka/values.yaml
@@ -139,6 +139,8 @@ nodeport:
   servicePort: 19092
   firstListenerPort: 31090
 
+enableEnterpriseFeatures: true
+
 ## ------------------------------------------------------
 ## Zookeeper
 ## ------------------------------------------------------

--- a/charts/cp-kafka/values.yaml
+++ b/charts/cp-kafka/values.yaml
@@ -11,7 +11,7 @@ brokers: 3
 
 ## Image Info
 ## ref: https://hub.docker.com/r/confluentinc/cp-server/
-image: confluentinc/cp-server
+# image: confluentinc/cp-server
 imageTag: 6.2.1
 
 ## Specify a imagePullPolicy

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -26,4 +26,4 @@ dependencies:
 - name: cp-control-center
   version: 0.1.0
   repository: file://./charts/cp-control-center
-  condition: cp-control-center.enabled
+  condition: cp-kafka.enableEnterpriseFeatures, cp-control-center.enabled

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
 - name: cp-kafka
-  version: 0.1.0
+  version: 0.1.1
   repository: file://./charts/cp-kafka
   condition: cp-kafka.enabled
 - name: cp-zookeeper

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
 - name: cp-kafka
-  version: 0.1.1
+  version: 0.1.0
   repository: file://./charts/cp-kafka
   condition: cp-kafka.enabled
 - name: cp-zookeeper

--- a/values.yaml
+++ b/values.yaml
@@ -43,7 +43,7 @@ cp-zookeeper:
 cp-kafka:
   enabled: true
   brokers: 3
-  image: confluentinc/cp-enterprise-kafka
+  # image: confluentinc/cp-enterprise-kafka
   imageTag: 6.2.1
   ## Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
   ## https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod

--- a/values.yaml
+++ b/values.yaml
@@ -43,7 +43,7 @@ cp-zookeeper:
 cp-kafka:
   enabled: true
   brokers: 3
-  # image: confluentinc/cp-enterprise-kafka
+  # image: confluentinc/cp-server
   imageTag: 6.2.1
   ## Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
   ## https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a variable to cp-kafka/values.yaml to enable or disable enterprise
features. Same as https://github.com/confluentinc/cp-helm-charts/pull/436 .

Fixes #377

This PR is based on the work of @oscarh on #378.

## How was this patch tested?
```
helm template --set cp-kafka.enableEnterpriseFeatures=false . > /tmp/kafka_enterprise_disabled.yaml
helm template --set cp-kafka.enableEnterpriseFeatures=true . > /tmp/kafka_enterprise_enabled.yaml
diff -u /tmp/kafka_enterprise_{enabled,disabled}.yaml
```
```
--- /tmp/kafka_enterprise_enabled.yaml	2021-12-14 20:51:50.000000000 +0100
+++ /tmp/kafka_enterprise_disabled.yaml	2021-12-14 20:51:50.000000000 +0100
@@ -241,24 +241,6 @@
         replicaId: "$2"
         memberType: "$3"
 ---
-# Source: cp-helm-charts/charts/cp-control-center/templates/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: RELEASE-NAME-cp-control-center
-  labels:
-    app: cp-control-center
-    chart: cp-control-center-0.1.0
-    release: RELEASE-NAME
-    heritage: Helm
-spec:
-  ports:
-    - name: cc-http
-      port: 9021
-  selector:
-    app: cp-control-center
-    release: RELEASE-NAME
----
 # Source: cp-helm-charts/charts/cp-kafka-connect/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -420,59 +402,6 @@
     app: cp-zookeeper
     release: RELEASE-NAME
 ---
-# Source: cp-helm-charts/charts/cp-control-center/templates/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: RELEASE-NAME-cp-control-center
-  labels:
-    app: cp-control-center
-    chart: cp-control-center-0.1.0
-    release: RELEASE-NAME
-    heritage: Helm
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: cp-control-center
-      release: RELEASE-NAME
-  template:
-    metadata:
-      labels:
-        app: cp-control-center
-        release: RELEASE-NAME
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "5556"
-    spec:
-      containers:
-        - name: cp-control-center
-          image: "confluentinc/cp-enterprise-control-center:6.2.1"
-          imagePullPolicy: IfNotPresent
-          ports:
-            - name: cc-http
-              containerPort: 9021
-              protocol: TCP
-          resources:
-            {}
-          env:
-            - name: CONTROL_CENTER_BOOTSTRAP_SERVERS
-              value: PLAINTEXT://RELEASE-NAME-cp-kafka-headless:9092
-            - name: CONTROL_CENTER_ZOOKEEPER_CONNECT
-              value:
-            - name: CONTROL_CENTER_CONNECT_CLUSTER
-              value: http://RELEASE-NAME-cp-kafka-connect:8083
-            - name: CONTROL_CENTER_KSQL_URL
-              value: http://RELEASE-NAME-cp-ksql-server:8088
-            - name: CONTROL_CENTER_KSQL_ADVERTISED_URL
-              value: http://RELEASE-NAME-cp-ksql-server:8088
-            - name: CONTROL_CENTER_SCHEMA_REGISTRY_URL
-              value: http://RELEASE-NAME-cp-schema-registry:8081
-            - name: KAFKA_HEAP_OPTS
-              value: "-Xms512M -Xmx512M"
-            - name: "CONTROL_CENTER_REPLICATION_FACTOR"
-              value: "3"
----
 # Source: cp-helm-charts/charts/cp-kafka-connect/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -881,7 +810,7 @@
         - name: jmx-config
           mountPath: /etc/jmx-kafka
       - name: cp-kafka-broker
-        image: "confluentinc/cp-server:6.2.1"
+        image: "confluentinc/cp-kafka:6.2.1"
         imagePullPolicy: "IfNotPresent"
         securityContext:
           runAsUser: 0
@@ -915,10 +844,6 @@
           value: "RELEASE-NAME-cp-zookeeper-headless:2181"
         - name: KAFKA_LOG_DIRS
           value: "/opt/kafka/data-0/logs"
-        - name: KAFKA_METRIC_REPORTERS
-          value: "io.confluent.metrics.reporter.ConfluentMetricsReporter"
-        - name: CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS
-          value: "PLAINTEXT://RELEASE-NAME-cp-kafka-headless:9092"
         - name: "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP"
           value: "PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT"
         - name: "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR"
```