### PR TITLE
Custom scripts for kafka connect

### DIFF
--- a/charts/cp-kafka-connect/README.md
+++ b/charts/cp-kafka-connect/README.md
@@ -163,10 +163,11 @@ The configuration parameters in this section control the resources requested and
 
 ### Running Custom Scripts
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `customEnv.CUSTOM_SCRIPT_PATH` | Path to external bash script to run inside the container | see [values.yaml](values.yaml) for details |
-| `livenessProbe` | Requirement of `livenessProbe` depends on the custom script to be run  | see [values.yaml](values.yaml) for details |
+| Parameter                              | Description                                                                   | Default |
+|----------------------------------------|-------------------------------------------------------------------------------| ------- |
+| `customEnv.CUSTOM_SCRIPT_PATH`         | Path to external bash script to run inside the container                      | see [values.yaml](values.yaml) for details |
+| `customEnv.CUSTOM_SCRIPT_PATH_PRE_RUN` | Path to external bash script to run inside the container before kafka connect | see [values.yaml](values.yaml) for details |
+| `livenessProbe`                        | Requirement of `livenessProbe` depends on the custom script to be run         | see [values.yaml](values.yaml) for details |
 
 ### Deployment Topology
 

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -107,6 +107,9 @@ spec:
             - /bin/bash
             - -c
             - |
+              {{- if .Values.customEnv.CUSTOM_SCRIPT_PATH_PRE_RUN }}
+              $CUSTOM_SCRIPT_PATH_PRE_RUN
+              {{- end }}
               /etc/confluent/docker/run &
               $CUSTOM_SCRIPT_PATH
               sleep infinity

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -112,7 +112,6 @@ spec:
               {{- end }}
               /etc/confluent/docker/run &
               $CUSTOM_SCRIPT_PATH
-              sleep infinity
           {{- if .Values.livenessProbe }}
           livenessProbe:
 {{ toYaml .Values.livenessProbe | trim | indent 12 }}

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -39,8 +39,11 @@ heapOptions: "-Xms512M -Xmx512M"
 
 ## Additional env variables
 ## CUSTOM_SCRIPT_PATH is the path of the custom shell script to be ran mounted in a volume
+## CUSTOM_SCRIPT_PATH_PRE_RUN is the path of the custom shell script to be run before kafka connect
+##   and to be ran mounted in a volume
 customEnv: {}
   # CUSTOM_SCRIPT_PATH: /etc/scripts/create-connectors.sh
+  # CUSTOM_SCRIPT_PATH_PRE_RUN: /etc/scripts/install-connectors.sh
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/examples/create-connectors.sh
+++ b/examples/create-connectors.sh
@@ -3,6 +3,8 @@
 
 # TODO: change this to use https://github.com/kcctl/kcctl
 echo "Waiting for Kafka Connect to start listening on kafka-connect  "
+TIMEOUT="${CONNECT_CUB_KAFKA_TIMEOUT:-40}"
+start_time=$(date +%s)
 while :; do
     # Check if the connector endpoint is ready
     # If not check again
@@ -15,6 +17,11 @@ while :; do
     # shellcheck disable=SC2086
     if [ $curl_status -eq 200 ]; then
         break
+    fi
+    end_time=$(date +%s)
+    elapsed=$(( end_time - start_time ))
+    if [ "$elapsed" -gt "$TIMEOUT" ]; then
+      exit 1
     fi
     sleep 5
 done
@@ -36,3 +43,5 @@ curl -X POST \
         "poll.interval.ms": 1000
         }
     }' http://"$CONNECT_REST_ADVERTISED_HOST_NAME":8083/connectors
+
+sleep infinity


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Added `CUSTOM_SCRIPT_PATH_PRE_RUN` script to kafka connect to be run **before** kafka connect. This is important when you want to install custom connector JARs (e.g. Debezium)
2. Fixed `command` section in kafka connect `deployment.yaml`. In the official images from Confluent, `/etc/confluent/docker/run` exits when kafka brokers are not ready within a timeout (default: 40 seconds). Now, in the official images, once the timeout expires, the `/etc/confluent/docker/run` script **exits** and the pod reboots. When using a custom script, however, `/etc/confluent/docker/run` is run in background and if it exits, it is goes unnoticed. For this reason, it's necessary to deal with that timeout **within** the `CUSTOM_SCRIPT_PATH` script, otherwise the custom script could hang forever. 

## How was this patch tested?

Helm install on Kubernetes on AWS.
