### PR TITLE
[Kafka-Connect] Adds support for secrets as environment variables

### DIFF
--- a/charts/cp-kafka-connect/README.md
+++ b/charts/cp-kafka-connect/README.md
@@ -122,6 +122,7 @@ The configuration parameters in this section control the resources requested and
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `secrets` | Secret with one or more `key:value` pairs | see [values.yaml](values.yaml) for details |
+| `envFromSecrets` | Secrets injected as environment variables | see [values.yaml](values.yaml) for details |
 
 ### Kafka Connect JVM Heap Options
 

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -102,12 +102,11 @@ spec:
             - name: KAFKA_JMX_PORT
               value: "{{ .Values.jmx.port }}"
             {{- end }}
-            {{- $secretName := (include "cp-kafka-connect.fullname" .) -}}
             {{- range $key,$value := .Values.envFromSecrets }}
             - name: {{$key | quote}}
               valueFrom:
                   secretKeyRef:
-                    name: {{ $secretName }}
+                    name: {{ $value.secret | quote }}
                     key: {{ $value.key | quote }}
             {{- end }}
         {{- if .Values.customEnv.CUSTOM_SCRIPT_PATH }}

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -102,6 +102,14 @@ spec:
             - name: KAFKA_JMX_PORT
               value: "{{ .Values.jmx.port }}"
             {{- end }}
+            {{- $secretName := (include "cp-kafka-connect.fullname" .) -}}
+            {{- range $key,$value := .Values.envFromSecrets }}
+            - name: {{$key | quote}}
+              valueFrom:
+                  secretKeyRef:
+                    name: {{ $secretName }}
+                    key: {{ $value.key | quote }}
+            {{- end }}
         {{- if .Values.customEnv.CUSTOM_SCRIPT_PATH }}
           command:
             - /bin/bash

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -121,6 +121,16 @@ secrets:
   # username: kafka123
   # password: connect321
 
+## Environment variables from previously created Secret resource.
+## Take the example secret from above with 2 properties (username & password
+## Creates 2 environment variables (USER & PASSWORD) with the respective content from the secret.
+envFromSecrets:
+#  USER:
+#    key: username
+#  PASSWORD:
+#    key: password
+
+
 ## These values are used only when "customEnv.CUSTOM_SCRIPT_PATH" is defined.
 ## "livenessProbe" is required only for the edge cases where the custom script to be ran takes too much time
 ## and errors by the ENTRYPOINT are ignored by the container

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -122,12 +122,14 @@ secrets:
   # password: connect321
 
 ## Environment variables from previously created Secret resource.
-## Take the example secret from above with 2 properties (username & password
-## Creates 2 environment variables (USER & PASSWORD) with the respective content from the secret.
+## Suppose you have a secret called connect-secrets with 2 properties: username & password.
+## envFromSecrets creates 2 environment variables (USER & PASSWORD) with the content from the secret connect-secrets.
 envFromSecrets:
 #  USER:
+#    secret: connect-secrets
 #    key: username
 #  PASSWORD:
+#    secret: connect-secrets
 #    key: password
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adds `envFromSecrets` as an extra configuration for Kafka-Connect deployment resources.
This allows users to specify secrets and add them to the Kafka Connect server pods as environment variables. This makes it possible out of the box to configure the pod to work with connectors such as the[ S3 Sink](https://docs.confluent.io/kafka-connect-s3-sink/current/overview.html#credentials-provider-chain) connector that require secret configuration to work.

## How was this patch tested?
Helm install dry-run to validate correct deployment definition.
Deployed in AWS cluster successfully.