### PR TITLE
[Schema Registry] Adds SSL support via environment variables 

### DIFF
--- a/charts/cp-schema-registry/README.md
+++ b/charts/cp-schema-registry/README.md
@@ -104,6 +104,7 @@ The configuration parameters in this section control the resources requested and
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `configurationOverrides` | Schema Registry [configuration](https://docs.confluent.io/current/schema-registry/docs/config.html) overrides in the dictionary format. | `{}` |
+| `sslSecrets` | sslSecret definitions | `{}` see [values.yaml](values.yaml) for details |
 | `customEnv` | Custom environmental variables | `{}` |
 
 ### Port
@@ -147,7 +148,6 @@ The configuration parameters in this section control the resources requested and
 | `securityContext.runAsGroup` | All processes for the container will run with this primary group ID | 10001
 | `securityContext.fsGroup` | All processes for the container will run with this supplementary group ID | 10001
 | `securityContext.runAsNonRoot` | The kubelet will validate the image at runtime to make sure that it does not run as UID 0 (root) and won’t start the container if it does | true
-
 
 ### JMX Configuration
 

--- a/charts/cp-schema-registry/templates/deployment.yaml
+++ b/charts/cp-schema-registry/templates/deployment.yaml
@@ -92,6 +92,15 @@ spec:
           - name: SCHEMA_REGISTRY_{{ $configName | replace "." "_" | upper }}
             value: {{ $configValue | quote }}
           {{ end }}
+          {{- if .Values.sslSecrets }}
+          {{- range $envVarName, $envVarValue := .Values.sslSecrets.secureEnv }}
+          - name: SCHEMA_REGISTRY_{{ $envVarName | replace "." "_" | upper }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ $.Values.sslSecrets.name }}
+                key: {{ $envVarValue }}
+          {{- end }}
+          {{- end }}
           {{- range $key, $value := .Values.customEnv }}
           - name: {{ $key | quote }}
             value: {{ $value | quote }}
@@ -104,6 +113,11 @@ spec:
           - name: JMX_PORT
             value: "{{ .Values.jmx.port }}"
           {{- end }}
+          volumeMounts:
+          {{- with .Values.sslSecrets }}
+            - name: certs-dir
+              mountPath: {{ .path | default "/mnt/certs" }}
+          {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
@@ -113,6 +127,12 @@ spec:
       - name: jmx-config
         configMap:
           name: {{ template "cp-schema-registry.fullname" . }}-jmx-configmap
+      {{- end }}
+      {{- with .Values.sslSecrets }}
+      - name: certs-dir
+        secret:
+          defaultMode: 0444
+          secretName: {{ .name }}
       {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector:

--- a/charts/cp-schema-registry/values.yaml
+++ b/charts/cp-schema-registry/values.yaml
@@ -27,6 +27,23 @@ imagePullSecrets:
 ## Configuration Options can be found here: https://docs.confluent.io/current/schema-registry/docs/config.html
 configurationOverrides: {}
 
+## SSL configuration
+### Works by specifying a Secret resources called "ssl-config" where each key in `secureEnv` is translated to the
+# equivalent environment variable.
+# I.e: kafkastore.ssl.key.password is converted to SCHEMA_REGISTRY_KAFKASTORE_SSL_KEY_PASSWORD
+sslSecrets: {}
+#  name: ssl-config
+#  path: /mnt/certs
+#  secureEnv:
+#    kafkastore.ssl.keystore.password: keystore_password
+#    kafkastore.ssl.key.password: keystore_password
+#    kafkastore.ssl.truststore.password: truststore_password
+## SSLSecrets must be used in conjunction with the following configuration (adjust as necessary).
+#  configurationOverrides:
+#    kafkastore.security.protocol: SSL
+#    kafkastore.ssl.keystore.location: /mnt/certs/keystore
+#    kafkastore.ssl.truststore.location: /mnt/certs/truststore
+
 ## Additional env variables
 customEnv: {}
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adds `sslSecrets` as an extra configuration for Schema Registry deployment resource.
This allows users to specify secrets with SSL information and bind them to a Schema Registry deployment.

## How was this patch tested?
Helm install dry-run to validate correct deployment definition.
Deployed in AWS cluster successfully.

If approved I can apply this to other Kafka charts as needed.