### PR TITLE
allow resource name to use property fullnameOverride

### DIFF
--- a/charts/cp-control-center/templates/_helpers.tpl
+++ b/charts/cp-control-center/templates/_helpers.tpl
@@ -36,8 +36,12 @@ Create a default fully qualified kafka headless name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "cp-control-center.cp-kafka-headless.fullname" -}}
+{{- if (index .Values.fullnameOverride) -}}
+{{- printf "%s-headless" (index .Values.fullnameOverride) | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := "cp-kafka-headless" -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*
@@ -57,8 +61,12 @@ Create a default fully qualified schema registry name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "cp-control-center.cp-schema-registry.fullname" -}}
+{{- if (index .Values "cp-schema-registry" "fullnameOverride") -}}
+{{- printf "%s" (index .Values "cp-schema-registry" "fullnameOverride") | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default "cp-schema-registry" (index .Values "cp-schema-registry" "nameOverride") -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "cp-control-center.cp-schema-registry.service-name" -}}
@@ -74,9 +82,14 @@ Create a default fully qualified connect name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "cp-control-center.cp-kafka-connect.fullname" -}}
+{{- if (index .Values "cp-kafka-connect" "fullnameOverride") -}}
+{{- printf "%s" (index .Values "cp-kafka-connect" "fullnameOverride") | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default "cp-kafka-connect" (index .Values "cp-kafka-connect" "nameOverride") -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+{{- end -}}
+
 
 {{- define "cp-control-center.cp-kafka-connect.service-name" -}}
 {{- if (index .Values "cp-kafka-connect" "url") -}}
@@ -91,9 +104,14 @@ Create a default fully qualified ksql name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "cp-control-center.cp-ksql-server.fullname" -}}
+{{- if (index .Values "cp-ksql-server" "fullnameOverride") -}}
+{{- printf "%s" (index .Values "cp-ksql-server" "fullnameOverride") | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default "cp-ksql-server" (index .Values "cp-ksql-server" "nameOverride") -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+{{- end -}}
+
 
 {{- define "cp-control-center.cp-ksql-server.service-name" -}}
 {{- if (index .Values "cp-ksql-server" "url") -}}
@@ -108,9 +126,14 @@ Create a default fully qualified zookeeper name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "cp-control-center.cp-zookeeper.fullname" -}}
+{{- if (index .Values "cp-zookeeper" "fullnameOverride") -}}
+{{- printf "%s" (index .Values "cp-zookeeper" "fullnameOverride") | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default "cp-zookeeper" (index .Values "cp-zookeeper" "nameOverride") -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+{{- end -}}
+
 
 {{/*
 Form the Zookeeper URL. If zookeeper is installed as part of this chart, use k8s service discovery,

--- a/charts/cp-kafka-connect/templates/_helpers.tpl
+++ b/charts/cp-kafka-connect/templates/_helpers.tpl
@@ -36,8 +36,12 @@ Create a default fully qualified kafka headless name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "cp-kafka-connect.cp-kafka-headless.fullname" -}}
+{{- if (index .Values "cp-kafka" "fullnameOverride") -}}
+{{- printf "%s-headless" (index .Values "cp-kafka" "fullnameOverride") | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := "cp-kafka-headless" -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*
@@ -57,8 +61,12 @@ Create a default fully qualified schema registry name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "cp-kafka-connect.cp-schema-registry.fullname" -}}
+{{- if (index .Values "cp-schema-registry" "fullnameOverride") -}}
+{{- printf "%s" (index .Values "cp-schema-registry" "fullnameOverride") | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default "cp-schema-registry" (index .Values "cp-schema-registry" "nameOverride") -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "cp-kafka-connect.cp-schema-registry.service-name" -}}

--- a/charts/cp-kafka-rest/templates/_helpers.tpl
+++ b/charts/cp-kafka-rest/templates/_helpers.tpl
@@ -96,8 +96,8 @@ Form the Kafka URL. If Kafka is installed as part of this chart, use k8s service
 else use user-provided URL
 */}}
 {{- define "cp-kafka-rest.kafka.bootstrapServers" -}}
-{{- if (index .Values "cp-kafka" "bootstrapServers") -}}
-{{- printf "%s" (index .Values "cp-kafka" "bootstrapServers") -}}
+{{- if .Values.kafka.bootstrapServers -}}
+{{- .Values.kafka.bootstrapServers -}}
 {{- else -}}
 {{- printf "PLAINTEXT://%s:9092" (include "cp-kafka-rest.cp-kafka-headless.fullname" .) -}}
 {{- end -}}

--- a/charts/cp-kafka-rest/templates/_helpers.tpl
+++ b/charts/cp-kafka-rest/templates/_helpers.tpl
@@ -36,8 +36,12 @@ Create a default fully qualified zookeeper name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "cp-kafka-rest.cp-zookeeper.fullname" -}}
+{{- if (index .Values "cp-zookeeper" "fullnameOverride") -}}
+{{- printf "%s" (index .Values "cp-zookeeper" "fullnameOverride") | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default "cp-zookeeper" (index .Values "cp-zookeeper" "nameOverride") -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*
@@ -58,8 +62,12 @@ Create a default fully qualified schema registry name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "cp-kafka-rest.cp-schema-registry.fullname" -}}
+{{- if (index .Values "cp-schema-registry" "fullnameOverride") -}}
+{{- printf "%s" (index .Values "cp-schema-registry" "fullnameOverride") | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default "cp-schema-registry" (index .Values "cp-schema-registry" "nameOverride") -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "cp-kafka-rest.cp-schema-registry.service-name" -}}
@@ -70,14 +78,23 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
-{{/*Create a default fully qualified kafka headless name.
+{{/*
+Create a default fully qualified kafka headless name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "cp-kafka-rest.cp-kafka-headless.fullname" -}}
+{{- if (index .Values "cp-kafka" "fullnameOverride") -}}
+{{- printf "%s-headless" (index .Values "cp-kafka" "fullnameOverride") | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := "cp-kafka-headless" -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+{{- end -}}
 
+{{/*
+Form the Kafka URL. If Kafka is installed as part of this chart, use k8s service discovery,
+else use user-provided URL
+*/}}
 {{- define "cp-kafka-rest.kafka.bootstrapServers" -}}
 {{- if (index .Values "cp-kafka" "bootstrapServers") -}}
 {{- printf "%s" (index .Values "cp-kafka" "bootstrapServers") -}}

--- a/charts/cp-kafka-rest/values.yaml
+++ b/charts/cp-kafka-rest/values.yaml
@@ -99,5 +99,5 @@ cp-zookeeper:
 cp-schema-registry:
   url: ""
 
-cp-kafka:
+kafka:
   bootstrapServers: ""

--- a/charts/cp-kafka/templates/_helpers.tpl
+++ b/charts/cp-kafka/templates/_helpers.tpl
@@ -35,9 +35,14 @@ Create chart name and version as used by the chart label.
 Create a default fully qualified zookeeper name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
+
 {{- define "cp-kafka.cp-zookeeper.fullname" -}}
+{{- if (index .Values "cp-zookeeper" "fullnameOverride") -}}
+{{- printf "%s-headless" (index .Values "cp-zookeeper" "fullnameOverride") | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default "cp-zookeeper" (index .Values "cp-zookeeper" "nameOverride") -}}
 {{- printf "%s-%s-headless" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*
@@ -72,8 +77,12 @@ Create a default fully qualified kafka headless name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "cp-kafka.cp-kafka-headless.fullname" -}}
+{{- if (index .Values.fullnameOverride) -}}
+{{- printf "%s-headless" (index .Values.fullnameOverride) | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := "cp-kafka-headless" -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/cp-ksql-server/templates/_helpers.tpl
+++ b/charts/cp-ksql-server/templates/_helpers.tpl
@@ -36,8 +36,12 @@ Create a default fully qualified kafka headless name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "cp-ksql-server.cp-kafka-headless.fullname" -}}
+{{- if (index .Values.fullnameOverride) -}}
+{{- printf "%s-headless" (index .Values.fullnameOverride) | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := "cp-kafka-headless" -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*
@@ -68,8 +72,12 @@ Create a default fully qualified schema registry name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "cp-ksql-server.cp-schema-registry.fullname" -}}
+{{- if (index .Values "cp-schema-registry" "fullnameOverride") -}}
+{{- printf "%s" (index .Values "cp-schema-registry" "fullnameOverride") | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default "cp-schema-registry" (index .Values "cp-schema-registry" "nameOverride") -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "cp-ksql-server.cp-schema-registry.service-name" -}}

--- a/charts/cp-schema-registry/templates/_helpers.tpl
+++ b/charts/cp-schema-registry/templates/_helpers.tpl
@@ -36,8 +36,12 @@ Create a default fully qualified kafka headless name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "cp-kafka-rest.cp-kafka-headless.fullname" -}}
+{{- if (index .Values "cp-kafka" "fullnameOverride") -}}
+{{- printf "%s-headless" (index .Values "cp-kafka" "fullnameOverride") | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := "cp-kafka-headless" -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. helm upgrade on minikube, helm install on gke)

````
kubectl -n test-cicd get pods
NAME                                        READY   STATUS    RESTARTS          AGE
kafka-cp-kafka-0                            2/2     Running   0                 2d18h
kafka-cp-kafka-connect-578c7985dd-7k557     2/2     Running   0                 2d17h
kafka-cp-kafka-rest-749f7df76-qdlgd         2/2     Running   0                 2d17h
kafka-cp-schema-registry-548c575d59-q62pg   2/2     Running   0                 2d17h
kafka-cp-zookeeper-0                        2/2     Running   0                 2d18h

kubectl -n test-cicd get svc
NAME                          TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                               AGE
kafka-cp-kafka                ClusterIP   10.103.208.227   <none>        9092/TCP,5556/TCP                     2d18h
kafka-cp-kafka-connect        ClusterIP   10.100.193.237   <none>        8083/TCP,5556/TCP                     2d18h
kafka-cp-kafka-headless       ClusterIP   None             <none>        9092/TCP                              2d18h
kafka-cp-kafka-rest           ClusterIP   10.101.155.228   <none>        8082/TCP,5556/TCP                     2d18h
kafka-cp-schema-registry      ClusterIP   10.102.83.211    <none>        8081/TCP,5556/TCP                     2d18h
kafka-cp-zookeeper            ClusterIP   10.103.107.89    <none>        2181/TCP,5556/TCP                     2d18h
kafka-cp-zookeeper-headless   ClusterIP   None             <none>        2888/TCP,3888/TCP                     2d18h
root@lnx-kub14:~#
````

my values.yaml with fullnameOverride
````
kafka:
  enabled: true

  cp-zookeeper:
    fullnameOverride: kafka-cp-zookeeper
    servers: 1
    imageTag: 6.2.2
    resources:
      limits:
        cpu: 2000m
        memory: 2Gi
      requests:
        cpu: 1000m
        memory: 1Gi
    persistence:
      enabled: false

  cp-kafka:
    fullnameOverride: kafka-cp-kafka
    brokers: 1
    imageTag: 6.2.2
    persistence:
      enabled: false
    resources:
      limits:
        cpu: 4000m
        memory: 4Gi
      requests:
        cpu: 2000m
        memory: 2Gi
    configurationOverrides:
      "offsets.topic.replication.factor": "1"
      "metrics.topic.replication.factor": "1"
      "default.replication.factor": 1
      "confluent.metrics.reporter.topic.replicas": "1"
      KAFKA_BROKER_ID: 1
      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
      CONFLUENT_METRICS_TOPIC_REPLICATION: 1
      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
      CONFLUENT_SUPPORT_METRICS_ENABLE: "false"
      KAFKA_LOG_CLEANUP_POLICY: "compact,delete"
      KAFKA_LOG_CLEANER_ENABLE: "true"
      "listener.security.protocol.map": "PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT,EXTERNAL_2:PLAINTEXT,EXTERNAL_3:PLAINTEXT"
      "advertised.listeners": "EXTERNAL://192.168.50.30:31090,EXTERNAL_3://localhost:29092"
    cp-zookeeper:
      fullnameOverride: kafka-cp-zookeeper

  cp-kafka-connect:
    fullnameOverride: kafka-cp-kafka-connect
    imageTag: 6.2.2
    resources:
      limits:
        memory: 2Gi
      requests:
        cpu: 100m
        memory: 1Gi
    configurationOverrides:
      "config.storage.replication.factor": "1"
      "offset.storage.replication.factor": "1"
      "status.storage.replication.factor": "1"
      "confluent.metrics.reporter.topic.replicas": "1"
      CONTROL_CENTER_REPLICATION_FACTOR: 1
      CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS: 1
      CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS: 1
      CONFLUENT_METRICS_TOPIC_REPLICATION: 1
    cp-kafka:
      fullnameOverride: kafka-cp-kafka
    cp-schema-registry:
      fullnameOverride: kafka-cp-schema-registry


  cp-schema-registry:
    fullnameOverride: kafka-cp-schema-registry
    imageTag: 6.2.2
    resources:
      limits:
        cpu: 2000m
        memory: 2Gi
      requests:
        cpu: 100m
        memory: 1Gi
    enabled: true
    configurationOverrides:
      "kafkastore.timeout.ms": 3000
      "kafkastore.init.timeout.ms": 180000
      "kafkastore.topic.replication.factor": 1
      "confluent.metrics.reporter.topic.replicas": "1"
      CONFLUENT_METRICS_TOPIC_REPLICATION: 1
    cp-kafka:
      fullnameOverride: kafka-cp-kafka
    cp-zookeeper:
      fullnameOverride: kafka-cp-zookeeper


  cp-kafka-rest:
    fullnameOverride: kafka-cp-kafka-rest
    imageTag: 6.2.2
    resources:
      limits:
        memory: 2Gi
      requests:
        cpu: 100m
        memory: 1Gi
    cp-kafka:
      fullnameOverride: kafka-cp-kafka
    cp-zookeeper:
      fullnameOverride: kafka-cp-zookeeper
    cp-schema-registry:
      fullnameOverride: kafka-cp-schema-registry

  cp-ksql-server:
    fullnameOverride: kafka-cp-ksql-server
    enabled: false
    imageTag: 6.2.2
    resources:
      limits:
        cpu: 4000m
        memory: 3Gi
      requests:
        cpu: 3000m
        memory: 2Gi
    cp-schema-registry:
      fullnameOverride: kafka-cp-schema-registry


  cp-control-center:
    fullnameOverride: kafka-cp-control-center
    enabled: false
    imageTag: 6.2.2
    resources:
      limits:
        cpu: 4000m
        memory: 4Gi
      requests:
        cpu: 3000m
        memory: 2Gi
    configurationOverrides:
      "replication.factor": "1"
      "internal.topics.replication": "1"
      "monitoring.interceptor.topic.replication": "1"
      "metrics.topic.replication": "1"
      "command.topic.replication": "1"
      "confluent.metrics.reporter.topic.replicas": "1"
      CONFLUENT_SUPPORT_METRICS_ENABLE: "false"
      CONTROL_CENTER_REPLICATION_FACTOR: 1
      CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS: 1
      CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS: 1
      CONFLUENT_METRICS_TOPIC_REPLICATION: 1
    cp-kafka-connect:
      fullnameOverride: kafka-cp-kafka-connect
    cp-ksql-server:
      fullnameOverride: kafka-cp-ksql-server
    cp-zookeeper:
      fullnameOverride: kafka-cp-zookeeper
    cp-schema-registry:
      fullnameOverride: kafka-cp-schema-registry

  cp_control_center_loadbalancer:
    enabled: false
````

In argoCD we can see that the service name is like fullnameOverride
<img width="1920" alt="image" src="https://user-images.githubusercontent.com/191879/160392038-75670bef-2813-4ba9-9a37-51f070c30334.png">

IF I try to deploy Kafka helm chart with Argocd without the property : fullnameOverride I'll obtain the name with the namespace in it like

````
 Environment:
      KAFKA_REST_HOST_NAME:             (v1:status.podIP)
      KAFKA_REST_BOOTSTRAP_SERVERS:    PLAINTEXT://kubernetes-api-b2b-kafka-cp-kafka-headless:9092
      KAFKA_REST_SCHEMA_REGISTRY_URL:  http://kubernetes-api-b2b-kafka-cp-schema-registry:8081
````

and the pods will crash in a loop for that reason
````
NAME                                        READY   STATUS             RESTARTS       AGE
kafka-cp-control-center-6f6c6cb67-zc98g     0/1     CrashLoopBackOff   6 (72s ago)    9m28s
kafka-cp-kafka-0                            2/2     Running            5 (84s ago)    8m12s
kafka-cp-kafka-connect-5497b6db6f-tzlpn     1/2     CrashLoopBackOff   6 (44s ago)    9m28s
kafka-cp-kafka-rest-b8c874678-jcl7g         1/2     CrashLoopBackOff   6 (2m7s ago)   9m28s
kafka-cp-schema-registry-5757c665b8-r8rtj   1/2     CrashLoopBackOff   6 (100s ago)   9m28s
kafka-cp-zookeeper-0                        2/2     Running            0              21m
````

if I use the fulloverride property, the pods are running fine
````
NAME                                        READY   STATUS    RESTARTS       AGE
kafka-cp-kafka-0                            2/2     Running   0              45m
kafka-cp-kafka-connect-56d48b4d9b-lrhlv     2/2     Running   3 (101m ago)   102m
kafka-cp-kafka-rest-56b9576d6-zlhvh         2/2     Running   3 (101m ago)   102m
kafka-cp-schema-registry-78b46f767d-lhsbb   2/2     Running   0              24s
kafka-cp-zookeeper-0                        2/2     Running   0              110m
````

````
 Environment:
      KAFKA_REST_HOST_NAME:             (v1:status.podIP)
      KAFKA_REST_BOOTSTRAP_SERVERS:    PLAINTEXT://kafka-cp-kafka-headless:9092
      KAFKA_REST_SCHEMA_REGISTRY_URL:  http://kafka-cp-schema-registry:8081
      KAFKAREST_HEAP_OPTS:             -Xms512M -Xmx512M
````